### PR TITLE
Add status tracking and configurable delay

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -11,8 +11,10 @@
         <div class="battle-ui">
             <div class="player-ui" id="p1Ui">
                 <h3 id="battlePlayer1"></h3>
+                <div class="hp-text" id="p1HpText">100</div>
                 <div class="hp-bar"><div id="p1HpFill" class="hp-fill"></div></div>
                 <div class="status">
+                    <span>状態:<span id="p1State">立ち</span></span>
                     <span>SS CD:<span id="p1SidestepCd">0</span></span>
                     <span>HC CD:<span id="p1HoldCounterCd">0</span></span>
                     <span>Trauma:<span id="p1Trauma">0</span></span>
@@ -21,8 +23,10 @@
             </div>
             <div class="player-ui" id="p2Ui">
                 <h3 id="battlePlayer2"></h3>
+                <div class="hp-text" id="p2HpText">100</div>
                 <div class="hp-bar"><div id="p2HpFill" class="hp-fill"></div></div>
                 <div class="status">
+                    <span>状態:<span id="p2State">立ち</span></span>
                     <span>SS CD:<span id="p2SidestepCd">0</span></span>
                     <span>HC CD:<span id="p2HoldCounterCd">0</span></span>
                     <span>Trauma:<span id="p2Trauma">0</span></span>

--- a/settings.html
+++ b/settings.html
@@ -18,6 +18,11 @@
             <textarea id="characterJson" rows="10" style="width:100%;"></textarea>
             <button onclick="importCharacters()">キャラデータインポート</button>
         </div>
+        <div class="input-section">
+            <label for="delayInput">技表示間隔(ms)</label>
+            <input id="delayInput" type="number" min="0">
+            <button onclick="saveDelay()">保存</button>
+        </div>
         <button onclick="deleteDatabase()">DB削除</button>
         <button onclick="backToTitle()">タイトルに戻る</button>
     </div>

--- a/style.css
+++ b/style.css
@@ -61,8 +61,12 @@ button:hover {
 
 .hp-fill {
     height: 100%;
-    background: red;
     width: 100%;
+}
+
+.hp-text {
+    font-size: 12px;
+    margin-bottom: 4px;
 }
 
 .status span {
@@ -74,7 +78,7 @@ button:hover {
 }
 
 .command-buttons button.selected {
-    background-color: green;
+    background-color: orange;
 }
 
 .command-buttons button.disabled {


### PR DESCRIPTION
## Summary
- show player state next to cooldowns
- continue battle until HP reaches -100
- support per-step HP updates and trauma after Hold Counter end
- allow adjusting log output delay and save in IndexedDB

## Testing
- `node --check script.js`
