### PR TITLE
Fix delay after KO

### DIFF
--- a/script.js
+++ b/script.js
@@ -372,7 +372,6 @@ class BattleSystem {
             await this.followUpDown(att, def, attPrefix, defPrefix, true);
             this.refreshPlayerUI(att, attPrefix);
             this.refreshPlayerUI(def, defPrefix);
-            await this.wait();
             return;
         }
 


### PR DESCRIPTION
## Summary
- remove unneeded wait after follow-up logic when a player falls to zero HP

## Testing
- `git status --short`
