### PR TITLE
Add player control options and manual command input

### DIFF
--- a/characterSelect.html
+++ b/characterSelect.html
@@ -27,6 +27,14 @@
                     <option value="">-- 性格を選択 --</option>
                 </select>
 
+                <label for="player1Control">操作:</label>
+                <select id="player1Control">
+                    <option value="player">プレイヤー</option>
+                    <option value="cpu-weak">CPU（弱）</option>
+                    <option value="cpu-medium" selected>CPU（中）</option>
+                    <option value="cpu-strong">CPU（強）</option>
+                </select>
+
                 <label for="player1Name">自動設定されたキャラクター名:</label>
                 <input type="text" id="player1Name" readonly style="background-color: #e9e9e9;">
                 <div id="player1CharacterInfo">
@@ -51,6 +59,14 @@
                 <label for="player2TypeSelect">性格:</label>
                 <select id="player2TypeSelect" onchange="updatePlayerInfo('player2')">
                     <option value="">-- 性格を選択 --</option>
+                </select>
+
+                <label for="player2Control">操作:</label>
+                <select id="player2Control">
+                    <option value="player">プレイヤー</option>
+                    <option value="cpu-weak">CPU（弱）</option>
+                    <option value="cpu-medium" selected>CPU（中）</option>
+                    <option value="cpu-strong">CPU（強）</option>
                 </select>
 
                 <label for="player2Name">自動設定されたキャラクター名:</label>

--- a/settings.html
+++ b/settings.html
@@ -23,6 +23,11 @@
             <input id="delayInput" type="number" min="0">
             <button onclick="saveDelay()">保存</button>
         </div>
+        <div class="input-section">
+            <label for="weakLoseInput">弱CPU失敗率(%)</label>
+            <input id="weakLoseInput" type="number" min="0" max="100">
+            <button onclick="saveWeakLosePercent()">保存</button>
+        </div>
         <button onclick="deleteDatabase()">DB削除</button>
         <button onclick="backToTitle()">タイトルに戻る</button>
     </div>


### PR DESCRIPTION
## Summary
- add control type dropdowns for both players in the character select screen
- allow storing selected control type when starting battle
- support player vs CPU by waiting for player command selection before CPU chooses
- implement simple AI selection and player input handling
- refine AI: weak CPUs can deliberately pick losing moves, strong CPUs avoid waste and consider opponent state
- add setting for weak CPU fail rate

## Testing
- `git status --short`
